### PR TITLE
Add EDA helper functions and tests for Milestone 3

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -2,6 +2,7 @@ library(readr)
 library(dplyr)
 library(rlang)
 library(tidyr)
+library(ggplot2)
 
 #' Prepare training data for knowledge level analysis
 #'
@@ -158,3 +159,53 @@ create_percentage_table <- function(data, path) {
     return(invisible(result))
 }
 
+#' Create a summary table for knowledge levels
+#'
+#' This function groups the training data by UNS level and computes summary
+#' statistics including count, mean, max, and min for STG and PEG.
+#' The summary is saved as a CSV to the given file path.
+#'
+#' @param data A data frame containing STG, PEG, and UNS columns
+#' @param path A string indicating where to save the resulting CSV file
+#'
+#' @return A summary data frame (invisible)
+#' @export
+create_uns_summary_table <- function(data, path) {
+  result <- data %>%
+    group_by(UNS) %>%
+    summarize(
+      count = n(),
+      mean_STG = mean(STG),
+      mean_PEG = mean(PEG),
+      max_STG = max(STG),
+      max_PEG = max(PEG),
+      min_STG = min(STG),
+      min_PEG = min(PEG)
+    )
+  write_csv(result, path)
+  return(invisible(result))
+}
+
+#' Plot a scatterplot of STG vs PEG colored by UNS
+#'
+#' This function creates a scatterplot of STG vs PEG colored by UNS level
+#' and saves the figure to a specified file path.
+#'
+#' @param data A data frame containing STG, PEG, and UNS columns
+#' @param path A string indicating the output file path for the plot
+#'
+#' @return The ggplot object (invisible)
+#' @export
+plot_stg_vs_peg_scatter <- function(data, path) {
+  plot <- data %>%
+    ggplot(aes(x = STG, y = PEG, colour = UNS)) +
+    labs(
+      x = "Degree of study time",
+      y = "Exam performance",
+      colour = "Knowledge Level of Users"
+    ) +
+    geom_point() +
+    theme(text = element_text(size = 20))
+  ggsave(filename = path, plot = plot, width = 6, height = 4, dpi = 300)
+  return(invisible(plot))
+}

--- a/test/tests.R
+++ b/test/tests.R
@@ -131,3 +131,47 @@ test_that("rename_column renames columns correctly", {
   expect_equal(df_renamed$new_name, c(1, 2, 3))
   expect_equal(df_renamed$other_col, c("A", "B", "C"))
 })
+
+# ---- Test create_uns_summary_table ----
+test_that("create_uns_summary_table computes correct stats and saves to CSV", {
+  dummy_data <- data.frame(
+    STG = c(1, 2, 3, 4, 5, 6, 7, 8),
+    PEG = c(10, 9, 8, 7, 6, 5, 4, 3),
+    UNS = factor(
+      c("Low", "Low", "Middle", "Middle", "High", "High", "very_low", "very_low"),
+      levels = c("very_low", "Low", "Middle", "High"),
+      ordered = TRUE
+    )
+  )
+
+  temp_path <- tempfile(fileext = ".csv")
+  result <- create_uns_summary_table(dummy_data, temp_path)
+
+  expect_s3_class(result, "data.frame")
+  expect_equal(nrow(result), 4)
+  expect_equal(names(result),
+               c("UNS", "count", "mean_STG", "mean_PEG", "max_STG", "max_PEG", "min_STG", "min_PEG"))
+  expect_true(file.exists(temp_path))
+  read_data <- read_csv(temp_path, show_col_types = FALSE)
+  expect_equal(nrow(read_data), 4)
+
+  file.remove(temp_path)
+})
+
+# ---- Test plot_stg_vs_peg_scatter ----
+test_that("plot_stg_vs_peg_scatter creates and saves a scatterplot", {
+  dummy_data <- data.frame(
+    STG = c(1, 2, 3),
+    PEG = c(10, 9, 8),
+    UNS = factor(c("Low", "Middle", "High"),
+                 levels = c("very_low", "Low", "Middle", "High"),
+                 ordered = TRUE)
+  )
+
+  temp_path <- tempfile(fileext = ".png")
+  plot_obj <- plot_stg_vs_peg_scatter(dummy_data, temp_path)
+
+  expect_s3_class(plot_obj, "gg")
+  expect_true(file.exists(temp_path))
+  file.remove(temp_path)
+})


### PR DESCRIPTION
## This PR addresses [Issue #14] tests as part of **Milestone 3**.

### What's Added

- `create_uns_summary_table(data, path)`
  - Groups by `UNS` and calculates summary stats (mean, min, max) for `STG` and `PEG`
  - Saves output as CSV

- `plot_stg_vs_peg_scatter(data, path)`
  - Generates a scatterplot of `STG` vs `PEG` colored by `UNS`
  - Saves plot as PNG

---

### Testing

- Added corresponding unit tests in `test/tests.R`
- All tests passed ✅ (run via `Rscript test/tests.R`)
- Verified handling of temp files and expected outputs

---

### Notes

- Required packages: `dplyr`, `readr`, `ggplot2`, `testthat`
- Functions are documented using roxygen2-style comments
- Ready to be integrated into the EDA script (`03_eda.R`)

---

Please review the new functions in `R/functions.R` and let me know if you'd like to suggest any refinements 
